### PR TITLE
add 'default' export

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
+    "default": "./dist/index.mjs",
     "module": "./dist/index.mjs",
     "require": "./dist/index.cjs",
     "types": "./dist/index.d.ts",


### PR DESCRIPTION
This is another fix from my contour-generator [patches](https://github.com/acalcutt/contour-generator/blob/main/patches/maplibre-contour%2B0.1.0.patch), which fixes an issue importing this package in node.js . Without this I had trouble using the package as an import and I had to use something like [this](https://github.com/acalcutt/contour-generator/blob/55a5013473f13f74da068f104a30b968a296bfd4/src/generate-countour-tile-pyramid.ts#L3)

With this fix, the package can be imported with just
`import mlcontour from "maplibre-contour";`