### PR TITLE
fix: prevent DEM requests below zoom level zero

### DIFF
--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -308,3 +308,38 @@ test("fake decode image and fetch tile", async () => {
   expect(demTile.data).toEqual(expectedElevations);
   expect(getTileSpy.mock.calls[0][0]).toBe("https://example/1/2/3.png");
 });
+
+test("fetchDem floors the DEM zoom at 0 when overzoom exceeds z", async () => {
+  const getTileSpy = jest.fn().mockReturnValue(Promise.resolve({}));
+  const demManager = new LocalDemManager({
+    demUrlPattern: "https://example/{z}/{x}/{y}.png",
+    cacheSize: 100,
+    encoding: "terrarium",
+    maxzoom: 11,
+    timeoutMs: 10000,
+    decodeImage: async () => ({
+      width: 4,
+      height: 4,
+      data: expectedElevations,
+    }),
+    getTile: getTileSpy,
+  });
+  const heightTile = await demManager.fetchDem(
+    1,
+    1,
+    1,
+    { overzoom: 2, levels: [10] },
+    new AbortController(),
+  );
+  // z1 asks for z-1; clamped to z0 and split into the bottom-right quarter
+  expect(getTileSpy.mock.calls[0][0]).toBe("https://example/0/0/0.png");
+  expect(heightTile.width).toBe(2);
+  expect(heightTile.height).toBe(2);
+  expect([
+    [heightTile.get(0, 0), heightTile.get(1, 0)],
+    [heightTile.get(0, 1), heightTile.get(1, 1)],
+  ]).toEqual([
+    [15, 5],
+    [5, 5],
+  ]);
+});

--- a/src/local-dem-manager.ts
+++ b/src/local-dem-manager.ts
@@ -137,7 +137,10 @@ export class LocalDemManager implements DemManager {
     abortController: AbortController,
     timer?: Timer,
   ): Promise<HeightTile> {
-    const zoom = Math.min(z - (options.overzoom || 0), this.maxzoom);
+    const zoom = Math.max(
+      0,
+      Math.min(z - (options.overzoom || 0), this.maxzoom),
+    );
     const subZ = z - zoom;
     const div = 1 << subZ;
     const newX = Math.floor(x / div);


### PR DESCRIPTION
`fetchDem` picks the DEM zoom as `min(z - overzoom, maxzoom)`. When `overzoom` is larger than the tile zoom this goes negative: with `overzoom=2` a z1 contour tile requests the DEM at zoom -1, the fetch fails, and z0/z1 tiles trace nothing regardless of the thresholds.

This clamps the DEM zoom at 0, so z0 and z1 tiles trace the z0 DEM tile (split into quarters for z1), the same way overzooming already works past `maxzoom`.

Adds a unit test that fails on `main` with `https://example/-1/0/0.png` being requested.

CI fails at `npm run test-build-v3` for every PR at the moment, independent of this change; the fix is #436.

Generated-By: Claude Fable 5.1 (claude-fable-5.1, via Claude Code); investigation, patch, and tests reviewed and verified by the submitter.

