### PR TITLE
ci: stop the test projects inheriting jest and node types so they compile on TypeScript 7

### DIFF
--- a/test-project-maplibre-3/tsconfig.json
+++ b/test-project-maplibre-3/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "../tsconfig.json",
+  "compilerOptions": { "types": [] },
   "include": ["*.ts"]
 }

--- a/test-project/tsconfig.json
+++ b/test-project/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "../tsconfig.json",
+  "compilerOptions": { "types": [] },
   "include": ["*.ts"]
 }


### PR DESCRIPTION
CI has failed at `npm run test-build-v3` on every run since TypeScript 7.0 shipped (2026-07-08), for example on #435:

```
../node_modules/@sinclair/typebox/typebox.d.ts(137,63): error TS2321: Excessive stack depth comparing types ...
```

Both test projects extend the root `tsconfig.json`, so they inherit `types: ["jest", "node"]` and `skipLibCheck: false`. Loading `@types/jest` pulls in `@jest/schemas` → `@sinclair/typebox` 0.27.8, and the compiler type-checks that file too. Its recursive `UnionToTuple` type passes on TypeScript 5.x and 6.x but fails on 7.0. The root project pins TypeScript 5.7.3 and is unaffected. The test projects install `typescript: "*"`, which has resolved to 7.x since July, so only the `test-build` steps break.

The test projects are browser-only consumers of `maplibre-contour` and `maplibre-gl` and use no jest or node globals, so this sets `types: []` on both. The compiler then only checks the `.d.ts` files reached through their imports, which is what these smoke tests are for, and `skipLibCheck` stays `false` so the published types are still checked under the latest TypeScript.

Verified locally with Node 20: both `npm run test-build-v3` and `npm run test-build` go from 3 errors to 0 and bundle.

Generated-By: Claude Fable 5.1 (claude-fable-5.1, via Claude Code); investigation, patch, and verification reviewed by the submitter.

